### PR TITLE
Fix sponsor logo sizing

### DIFF
--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -5,7 +5,7 @@
     <hr />
   </div>
   <div class="items">
-    <div class="sponsor">
+    <div class="sponsor with-spacing">
       <a href="https://github.com" target="_blank">
         <img src="/assets/images/sponsors/github-logo.png">
       </a>
@@ -16,10 +16,10 @@
     <div class="sponsor">
       <a href="https://appsignal.com" target="_blank">
         <img src="/assets/images/sponsors/appsignal-logo.png">
-        <p>
-          AppSignal gives you error tracking, performance monitoring, host metrics and anomaly detection in one great interface.
-        </p>
       </a>
+      <p>
+        AppSignal gives you error tracking, performance monitoring, host metrics and anomaly detection in one great interface.
+      </p>
     </div>
   </div>
 </article>
@@ -44,7 +44,7 @@
     <hr />
   </div>
   <div class="items">
-      <div class="sponsor">
+      <div class="sponsor with-spacing">
         <a href="https://stripe.com/jobs" target="_blank">
           <img src="/assets/images/sponsors/stripe-logo.svg">
         </a>
@@ -63,12 +63,12 @@
     <hr />
   </div>
   <div class="items">
-    <div class="sponsor">
+    <div class="sponsor sponsor-salonized">
       <a href="https://www.salonized.com/en" target="_blank">
         <img src="/assets/images/sponsors/salonized-logo.svg">
       </a>
     </div>
-    <div class="sponsor">
+    <div class="sponsor with-spacing">
       <a href="https://www.supersaas.com/" target="_blank">
         <img src="/assets/images/sponsors/supersaas_logo.png">
       </a>

--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -23,6 +23,20 @@
     </div>
   </div>
 </article>
+<div class="sponsor-container gold">
+  <div class="head">
+    <hr />
+    <p>Gold Sponsors</p>
+    <hr />
+  </div>
+  <div class="items">
+    <!--<div class="sponsor">
+      <a href="https://www.youngcapital.nl/" target="_blank">
+        <img src="/assets/images/sponsors/youngcapital-logo.svg">
+      </a>
+    </div>-->
+  </div>
+</div>
 <div class="sponsor-container silver">
   <div class="head">
     <hr />
@@ -40,20 +54,6 @@
         <img src="/assets/images/sponsors/phusion-logo.svg">
       </a>
     </div>
-  </div>
-</div>
-<div class="sponsor-container gold">
-  <div class="head">
-    <hr />
-    <p>Gold Sponsors</p>
-    <hr />
-  </div>
-  <div class="items">
-    <!--<div class="sponsor">
-      <a href="https://www.youngcapital.nl/" target="_blank">
-        <img src="/assets/images/sponsors/youngcapital-logo.svg">
-      </a>
-    </div>-->
   </div>
 </div>
 <div class="sponsor-container bronze">

--- a/_sass/sponsor-section.scss
+++ b/_sass/sponsor-section.scss
@@ -36,16 +36,40 @@
       flex-wrap: wrap;
       flex-direction: row;
       justify-content: center;
-      .sponsor {
-        margin: 0 50px;
-        padding: 0;
-        text-align: center;
-        img {
-          height: 55px;
+    }
+    .sponsor {
+      margin: 0 50px 30px 0;
+      padding: 0;
+      text-align: center;
+      &:nth-child(even) {
+        margin-right: 0;
+      }
+      a {
+        display: inline-block;
+        padding: 10px 0;
+        max-height: 55px;
+        height: 55px;
+      }
+      img {
+        max-height: inherit;
+        height: inherit;
+        max-width: 100%;
+        width: auto;
+      }
+      p {
+        max-width: 300px;
+        margin: 12px 0 0 0;
+      }
+      &.with-spacing {
+        a {
+          padding: 0;
+          max-height: 75px;
+          height: 75px;
         }
-        p {
-          max-width: 300px;
-          margin: 12px 0 0 0;
+      }
+      &.sponsor-salonized {
+        a {
+          width: 70%
         }
       }
     }
@@ -60,19 +84,29 @@
       margin: 20px 0 0 0;
     }
   }
-  @media(max-width: $medium-device) {
+  @media(max-width: 800px) {
+    .sponsor-container.platinum {
+      .sponsor {
+        margin-right: 0;
+        width: 100%;
+
+        p {
+          margin: 0 auto;
+        }
+      }
+    }
+  }
+  @media(max-width: 750px) {
     .sponsor-container {
-      &.platinum {
-        .items {
-          .sponsor {
-            margin-bottom: 30px;
-            img {
-              height: auto;
-              width: auto;
-              max-width: 100%;
-              max-height: 55px;
-            }
-          }
+      .sponsor {
+        margin-right: 0;
+        &.sponsor-salonized a {
+          height: 40px;
+        }
+      }
+      &:not(.platinum) {
+        .sponsor {
+          width: 100%;
         }
       }
     }


### PR DESCRIPTION
## Fix sizing of sponsor logos

Every sponsor has about the same size of their logo on screen now rather
than logos with certain dimensions being rendered bigger than others.

When logos included transparent spacing in the images I've made an
exception to give them more spacing so the actual visible part of the
logo is about the same size as the others.

Also tweaked the rest of the CSS to render better on devices with
smaller screens to have the same behavior.

### Screenshot on desktop

Before left, this PR right:

![image](https://user-images.githubusercontent.com/282402/52085751-8d2ed900-25a5-11e9-8867-e9256fb27219.png)


### Screenshot on mobile

![image](https://user-images.githubusercontent.com/282402/52085808-b7809680-25a5-11e9-8a1b-dbcda37ae53d.png)

## Move Gold sponsors above Silver 

As per commit title.