### PR TITLE
Fix schedule alignment

### DIFF
--- a/_sass/index.scss
+++ b/_sass/index.scss
@@ -299,10 +299,20 @@
           table {
             border-collapse: collapse;
             width: 100%;
+            .time {
+              min-width: 125px;
+            }
+            .event {
+              width: 80%;
+            }
             tbody {
               tr {
                 &:nth-child(odd) {
                   background: #e5ebec;
+                }
+                > td {
+                  font-feature-settings: "tnum";
+                  font-variant-numeric: tabular-nums;
                 }
                 td {
                   border: solid 1px rgba(136,166,200,0.43);
@@ -324,7 +334,7 @@
             margin-bottom: 40px;
           }
           .day-1, .day-2 {
-            width: auto;
+            width: 100%;
           }
         }
       }

--- a/index.html
+++ b/index.html
@@ -224,6 +224,10 @@ title: EuRuKo'19, June 21st - 22nd 2019, Rotterdam
       <div class="day-1">
         <h2>Friday, June 21</h2>
         <table>
+          <colgroup>
+            <col class="time">
+            <col class="event">
+          </colgroup>
           <tbody>
             <tr>
               <td>10:00 - 10:30</td>
@@ -287,6 +291,10 @@ title: EuRuKo'19, June 21st - 22nd 2019, Rotterdam
       <div class="day-2">
         <h2>Saturday, June 22</h2>
         <table>
+          <colgroup>
+            <col class="time">
+            <col class="event">
+          </colgroup>
           <tbody>
               <td>10:30 - 11:00</td>
               <td>Keynote</td>


### PR DESCRIPTION
This commit makes sure that all the times in the table are aligned under
one another in different rows. This makes the schedule more easy to
read, because the times aren't in a different position per row.

Also make sure every column doesn't use more space than it needs to and
has enough space on mobile.

## Screenshots

Left this PR, On the right what is currently live:

![euruko 19 june 21st - 22nd 2019 rotterdam 2019-02-03 22-21-32 2](https://user-images.githubusercontent.com/282402/52182932-0414dd80-2803-11e9-9b9f-3c99c65138df.png)

![euruko 19 june 21st - 22nd 2019 rotterdam 2019-02-03 22-24-32 1](https://user-images.githubusercontent.com/282402/52182934-08d99180-2803-11e9-8a87-f611cd8318c3.png)
