### PR TITLE
Fix schedule table on mobile Safari

### DIFF
--- a/_sass/index.scss
+++ b/_sass/index.scss
@@ -300,10 +300,12 @@
             border-collapse: collapse;
             width: 100%;
             .time {
-              min-width: 125px;
+              min-width: 130px;
+              max-width: 130px;
+              width: 130px;
             }
             .event {
-              width: 80%;
+              width: 70%;
             }
             tbody {
               tr {
@@ -335,6 +337,12 @@
           }
           .day-1, .day-2 {
             width: 100%;
+
+            table {
+              .event {
+                width: auto;
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Fix the schedule tables on mobile Safari by setting the width property
to `auto` so it will not try to cram the `80%` width into the event
column.

On other browsers you have a bit more padding on the right side of the
table cell with the time now, but that is hardly noticed and may be
fixed later with the `box-sizing: border-box` property set on all
elements.

## Screenshots

This PR on mobile:

![unadjustednonraw_thumb_13f9](https://user-images.githubusercontent.com/282402/52236099-33405300-28c6-11e9-9f32-47e083e9de20.jpg)

euruko2019.org on mobile:

![img_1501](https://user-images.githubusercontent.com/282402/52236092-30ddf900-28c6-11e9-800a-5a6d6e12ee4e.PNG)
