### PR TITLE
Update startup contest and rules

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+Hi there 👋
+
+Ready to submit your idea for the Startup contest?
+Please make sure you've read the contest rules before submitting your idea.
+Contest rules can be found in this issue: https://github.com/euruko/euruko2019.github.io/issues/9
+
+It's also possible to submit another kind of issue about the https://euruko2019.org/ website here.

--- a/index.html
+++ b/index.html
@@ -368,17 +368,19 @@ title: EuRuKo'19, June 21st - 22nd 2019, Rotterdam
 
   <section id="sponsor-booth" class="full-width">
     <div class="container">
-      <h1>Startup Contest - Win a sponsor booth!</h1>
+      <h1>Startup Contest - Win a booth!</h1>
       <p>
-        We appreciate that not every team can afford a sponsorship package, however much they’re looking for engineering talent. That’s why we’re giving away 1 booth spot, to the startup that comes up with the best idea in our <strong>Icebreaker Contest</strong>.
+        We understand that not every team can afford a sponsorship package, but do want to get their name out there. That’s why we’re giving away 1 booth spot, to the startup that comes up with the best idea in our <strong>Icebreaker Contest</strong>.
       </p>
       <p>
-        People come to EuRuKo to connect with other Rubyists. We’re looking for solutions to help them reach that goal. We’re not saying app (but maybe we are). We <strong>are</strong> saying Ruby. Help EuRuKo attendees expand their circle, and recruit alongside the big players.
+        People come to EuRuKo to connect with other Rubyists. We’re looking for solutions to help them reach that goal. We’re not saying app (but maybe we are). We <strong>are</strong> saying Ruby. Help EuRuKo attendees expand their circle, and promote alongside the big players!
       </p>
       <div class="post-link">
-        <p>Post a link to (a demonstration of) your solution to the EuRuKo repository's issues.</p>
-        <a href="https://github.com/euruko/euruko2019.github.io/issues" target="_blank" class="button bg-red outline proposal">Post your link</a>
-        <p>Until Friday April 5, 12PM CET</p>
+        <p>Post a your idea (or a demonstration) of your solution to the EuRuKo repository.</p>
+        <p>Read more about <a href="https://github.com/euruko/euruko2019.github.io/issues/9">the contest and its rules</a>.</p>
+
+        <a href="https://github.com/euruko/euruko2019.github.io/issues/new" target="_blank" class="button bg-red outline proposal">Post your idea</a>
+        <p>Contest closes Friday May 3rd, 12PM CET</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Add an issue template for GitHub issues so that users see a heads-up
about the contest rules in the default issue body. In case they missed
the rules link on the website.