### PR TITLE
Better placement of team images

### DIFF
--- a/_sass/index.scss
+++ b/_sass/index.scss
@@ -214,9 +214,6 @@
         flex-wrap: wrap;
 
         @import "member.scss";
-        .member {
-          margin: 0 10px;
-        }
       }
       @media(max-width: $medium-device) {
         .container {

--- a/_sass/member.scss
+++ b/_sass/member.scss
@@ -10,11 +10,9 @@ article.member {
   &> img {
     border-radius: 50%;
     width: 100%;
-    max-width: ($two-col - ($padding-col / 2));
     height: auto;
 
     @media (min-width: $semi-small-device) {
-      max-width: none;
       height: 140px;
     }
   }

--- a/_sass/member.scss
+++ b/_sass/member.scss
@@ -1,18 +1,29 @@
 article.member {
   margin-bottom: 30px;
-  max-width: $two-col;
+  max-width: $two-col - $padding-col;
   display: flex;
   flex-direction: column;
   text-align: center;
+  @media (min-width: $semi-small-device) {
+    max-width: $two-col;
+  }
   &> img {
     border-radius: 50%;
     width: 100%;
-    height: 140px;
+    max-width: ($two-col - ($padding-col / 2));
+    height: auto;
+
+    @media (min-width: $semi-small-device) {
+      max-width: none;
+      height: 140px;
+    }
   }
   span {
     font-size: 15px;
     color: $darker-text;
     margin-top: 18px;
+    white-space: nowrap;
+    align-self: center;
   }
   .social {
     margin-top: 22px;

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -11,6 +11,7 @@ $eleven-col: 860px;
 $twelve-col: 940px;
 $padding-col: 20px;
 
+$semi-small-device: 360px;
 $medium-device: 980px;
 $nav-collapse-threshold: 770px;
 


### PR DESCRIPTION
@raytalks 🥇 

**Better placement of team images**
- Removes `margin`: `0 10px` as it does nothing visually;
- Add `$semi-small-device` as `360px` var for media query;
- `article.member` add some extra responsive styles.

**Description:**
By visually changing only mobile styles, `320px` phones will now render teams neatly by subtracting column padding from the `max-width` of image containers.
Above `360px` some styles are reset to its original values (or optimised slightly).

**Before:**
![euruko2019 org_](https://user-images.githubusercontent.com/1241174/52589393-faacf600-2e3e-11e9-8270-ccdbce2c8e35.png)

**After:**
![0 0 0 0_4000_ 3](https://user-images.githubusercontent.com/1241174/52589400-fd0f5000-2e3e-11e9-8f66-c0e705a02372.png)
