### PR TITLE
Add Code of Conduct page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -10,7 +10,7 @@
       <li><a href="/#venue">Venue</a></li>
       <li><a href="/#schedule">Schedule</a></li>
       <li><a href="/#sponsors">Sponsors</a></li>
-      <li><a href="/#code-of-conduct">Code of Conduct</a></li>
+      <li><a href="/code-of-conduct">Code of Conduct</a></li>
     </ul>
   </div>
 </nav>

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -54,6 +54,7 @@ a {
 
 // Components
 @import "c-person.scss";
+@import "page-content.scss";
 
 // Homepage sections
 @import "index.scss";

--- a/_sass/code-of-conduct.scss
+++ b/_sass/code-of-conduct.scss
@@ -5,3 +5,9 @@
     margin: 0 auto
   }
 }
+
+#code-of-conduct-page {
+  header h2 {
+    text-transform: none;
+  }
+}

--- a/_sass/header.scss
+++ b/_sass/header.scss
@@ -46,7 +46,7 @@ header {
     font-size: 16px;
   }
 
-  &.sponsoring {
+  &.sub-pages {
     text-align: center;
 
     img {

--- a/_sass/page-content.scss
+++ b/_sass/page-content.scss
@@ -1,0 +1,8 @@
+.page-content {
+  .container {
+    width: 100%;
+    max-width: $eight-col;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -49,3 +49,7 @@ h3 {
 .center {
   text-align: center;
 }
+.anchor {
+  position: relative;
+  top: -108px; // Navigation header bar height + some extra spacing
+}

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -1,0 +1,99 @@
+---
+layout: default
+title: Code of Conduct
+id: code-of-conduct-page
+permalink: /code-of-conduct/
+---
+
+<header class="full-width sub-pages">
+  <div class="container">
+    <section class="info wide">
+      <img src="/assets/images/logo_clean.svg">
+      <h2>EuRuKo 2019</h2>
+      <h1>Code of Conduct</h1>
+    </section>
+  </div>
+</header>
+<main>
+  <section class="page-content">
+    <div class="container">
+      <p>
+        In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+      </p>
+      <p>
+        We adhere to the <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct" target="_blank">Contributor Convenant</a>. The full text can be found <a href="#code-of-conduct">here</a>.
+      </p>
+    </div>
+  </section>
+
+  <section class="page-content">
+    <div class="container">
+      <a id="code-of-conduct" class="anchor"></a>
+      <h2>Code of Conduct</h2>
+
+      <h3>Our Pledge</h3>
+
+      <p>
+        In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+      </p>
+
+      <h3>Our Standards</h3>
+
+      <p>
+        Examples of behavior that contributes to creating a positive environment include:
+      </p>
+
+      <ul>
+        <li>Using welcoming and inclusive language</li>
+        <li>Being respectful of differing viewpoints and experiences</li>
+        <li>Gracefully accepting constructive criticism</li>
+        <li>Focusing on what is best for the community</li>
+        <li>Showing empathy towards other community members</li>
+      </ul>
+
+      <p>
+        Examples of unacceptable behavior by participants include:
+      </p>
+
+      <ul>
+        <li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
+        <li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
+        <li>Public or private harassment</li>
+        <li>Publishing others’ private information, such as a physical or electronic address, without explicit permission</li>
+        <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
+      </ul>
+
+      <h3>Our Responsibilities</h3>
+
+      <p>
+        Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+      </p>
+
+      <p>
+        Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+      </p>
+
+      <h3>Scope</h3>
+
+      <p>
+        This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+      </p>
+
+      <h3>Enforcement</h3>
+
+      <p>
+        Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <a href="mailto:organisers@euruko.org">organisers@euruko.org</a>. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+      </p>
+
+      <p>
+        Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
+      </p>
+
+      <h3>Attribution</h3>
+
+      <p>
+        This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">www.contributor-covenant.org/version/1/4/code-of-conduct.html</a>
+      </p>
+    </div>
+  </section>
+</main>

--- a/index.html
+++ b/index.html
@@ -358,9 +358,7 @@ title: EuRuKo'19, June 21st - 22nd 2019, Rotterdam
         In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
       </p>
       <p>
-        We adhere to the <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct" target="_blank">Contributor Convenant</a>.
-        <!-- Don’t hesitate to reach out when you notice anything that goes against the spirit of our Code of Conduct:<br />
-        <a href="mailto:floor@euruko.org" class="contact">floor@euruko.org</a> or: <a href="mailto:rayta@euruko.org" class="contact">rayta@euruko.org</a> -->
+        <a href="/code-of-conduct/" class="button bg-red">Read our Code of Conduct</a>
       </p>
     </div>
   </section>

--- a/sponsoring.html
+++ b/sponsoring.html
@@ -5,7 +5,7 @@ id: sponsoring-page
 permalink: /sponsoring/
 ---
 
-<header class="full-width sponsoring">
+<header class="full-width sub-pages">
   <div class="container">
     <section class="info wide">
       <img src="/assets/images/logo_clean.svg">
@@ -13,7 +13,9 @@ permalink: /sponsoring/
       <h1>Become a sponsor.</h1>
       <p>EuRuKo is the annual European conference that brings all the good news about Ruby and its friends. Every year it takes place in a different European city, the location being chosen by the participants.</p>
       <p>As a sponsor you get the opportunity to reach an international crowd of talented developers. Review our packages and learn how your company can benefit from sponsoring the event.</p>
-      <a class="button bg-red" href="mailto:rayta@euruko.org?subject=Yes, tell me more about sponsoring">Yes, tell me more about sponsoring!</a>
+      <p>
+        <a class="button bg-red" href="mailto:rayta@euruko.org?subject=Yes, tell me more about sponsoring">Yes, tell me more about sponsoring!</a>
+      </p>
     </section>
   </div>
 </header>


### PR DESCRIPTION
Instead of linking to the contributor-covenant.org website, copy the
code of conduct and add its own page for it. Here we can then also add
the contact email address where users can reach us.

Closes #19 

## Screenshots

On the homepage:

![image](https://user-images.githubusercontent.com/282402/55263209-87393980-5270-11e9-88c6-c9db6cc2f019.png)

On `euruko2019.org/code-of-conduct`:

![Screen Shot 2019-03-29 at 22 18 32-fullpage](https://user-images.githubusercontent.com/282402/55263241-9fa95400-5270-11e9-9c69-46067f3e7a2b.png)
