### PR TITLE
remove Bilawal from the schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,78 +319,71 @@ title: EuRuKo'19, June 21st - 22nd 2019, Rotterdam
                 <tr>
                   <td colspan="2" class="talk-description">Testing in prod has gotten a bad rap. It's both inevitable - you can't know everything before you ship - and desirable. In modern complex systems, failure is a constant and the only guiding principle is that "users should never notice". So how do you test safely in prod, and how should you allocate your scarce engineering cycles between prod and staging?</td>
                 </tr>
-                <tr class="talk">
-                  <td>11:00</td>
-                  <td>How We’re Making Tech Documentation Better, Easier, And Less Boring - Bilawal Maheed</td>
-                </tr>
-                <tr>
-                  <td colspan="2" class="talk-description">Engineers optimize for scale. We think about writing the “best” code, designing non-flaky tests to give us confidence, and adopting the latest and greatest - but why do we still fail to write, maintain, and improve our docs? Given we all rely on docs, what went wrong?</td>
-                </tr>
                 <tr class="break">
-                  <td>11:30</td>
+                  <td>11:00</td>
                   <td>Break</td>
                 </tr>
                 <tr class="talk">
-                  <td>11:50</td>
+                  <td>11:20</td>
                   <td>A Plan towards Ruby 3 Types - Yusuke Endoh</td>
                 </tr>
                 <tr>
                   <td colspan="2" class="talk-description">We introduce Ruby Type Profiler which is one of the proposals for Ruby 3’s static analysis. As far as we know, it is only one approach to statically analyze a non-type-annotated program for MRI. We aim to realize a static analysis tool that imposes no change of the great Ruby programming experience.</td>
                 </tr>
                 <tr class="talk">
-                  <td>12:20</td>
+                  <td>11:50</td>
                   <td>Lightning Talks</td>
                 </tr>
                 <tr class="break">
-                  <td>12:50</td>
+                  <td>12:20</td>
                   <td>Lunch</td>
                 </tr>
                 <tr class="talk">
-                  <td>14:10</td>
+                  <td>13:40</td>
                   <td>The musical Ruby - Jan Krutisch</td>
                 </tr>
                 <tr>
                   <td colspan="2" class="talk-description">Let’s make some music with Ruby. After cheating a bit with the amazing SonicPi, we’ll drop down to the foundations - While explaining the basics of digital sound synthesis and a tiny bit of music theory, we’ll create a tune to dance to using nothing but pure Ruby.</td>
                 </tr>
                 <tr>
-                  <td>14:40</td>
+                  <td>14:10</td>
                   <td>City pitch</td>
                 </tr>
                 <tr class="break">
-                  <td>15:00</td>
+                  <td>14:30</td>
                   <td>Break</td>
                 </tr>
                 <tr class="talk">
-                  <td>15:20</td>
+                  <td>14:50</td>
                   <td>Steal this talk - Aaron Cruz</td>
                 </tr>
                 <tr>
                   <td colspan="2" class="talk-description">It’s been a long journey building “Talkie”, but in the process I’ve consumed 100’s of Ruby talks from over the last years and I want to boil them down to the best things I can fit into this time slot. This talk is like a listicle of listicles, a best of Ruby talks. Like if you soaked up all the Ruby talks, cooked them down into a thick paste and then smeared it all over the EuRuKo stage.</td>
                 </tr>
                 <tr class="talk">
-                  <td>15:50</td>
+                  <td>15:20</td>
                   <td>The Life-Changing Magic of Tidying Active Record Allocations - Richard Schneeman</td>
                 </tr>
                 <tr>
                   <td colspan="2" class="talk-description">Your app is slow. It does not spark joy. In this talk, we will use memory profiling tools to discover performance hotspots. We will use this technique with a real-world application to identify a piece of optimizable code in Active Record that leads to a patch with substantial page speed impact.</td>
                 </tr>
                 <tr>
-                  <td>16:20</td>
+                  <td>15:50</td>
                   <td>Break</td>
                 </tr>
                 <tr class="talk">
-                  <td>16:40</td>
+                  <td>16:10</td>
                   <td>Closing keynote: The Past, Present, and Future of Rails at GitHub - Eileen M. Uchitelle</td>
                 </tr>
                 <tr>
                   <td colspan="2" class="talk-description">We'll look at GitHub's story, our Rails upgrade, and how cumulative technical debt can stifle development. At the end we'll explore how we're staying up to date with Rails and our investment in the future of Rails.</td>
                 </tr>
                 <tr>
-                  <td>17:10</td>
+                  <td>16:40</td>
                   <td>Closing notes (+city reveal)</td>
                 </tr>
                 <tr>
-                  <td>17:20</td>
+                  <td>16:50</td>
                   <td>Conference end</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Removed Bilawal from the schedule and pulled it up:

10:15 Welcome
10:30 Keynote
11:00 Break
11:20 Mame
11:50 Lightning Talks
12:20 Lunch
13:40 Jan
14:10 City Pitch
14:30 Break
14:50 Aaron
15:20 Richard
15:50 Break
16:10 Keynote
16:40 Closing
16:50 End
20:00 #rubykaraoke

/cc @tombruijn @FloorD @raytalks 